### PR TITLE
NimBLE-Arduino 1.4x compatible callbacks

### DIFF
--- a/src/NimBLEOTA.cpp
+++ b/src/NimBLEOTA.cpp
@@ -9,6 +9,12 @@ class NimBLErecvFWCallback : public NimBLECharacteristicCallbacks {
   }
   private:
   void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) {
+    onWrite(pCharacteristic);
+  }
+  void onWrite(NimBLECharacteristic* pCharacteristic, ble_gap_conn_desc* desc) {
+    onWrite(pCharacteristic);
+  }
+  void onWrite(NimBLECharacteristic* pCharacteristic) {
     if (pCharacteristic->getValue().length() >= 4) {
       NimBLEAttValue data = pCharacteristic->getValue();
       _ota->FWHandler((uint8_t*)data.c_str(), pCharacteristic->getValue().length());
@@ -25,6 +31,12 @@ class NimBLEcommandCallback : public NimBLECharacteristicCallbacks {
   }
   private:
   void onWrite(NimBLECharacteristic* pCharacteristic, NimBLEConnInfo& connInfo) {
+    onWrite(pCharacteristic);
+  }
+  void onWrite(NimBLECharacteristic* pCharacteristic, ble_gap_conn_desc* desc) {
+    onWrite(pCharacteristic);
+  }
+  void onWrite(NimBLECharacteristic* pCharacteristic) {
     if (pCharacteristic->getValue().length() >= 20) {
       NimBLEAttValue data = pCharacteristic->getValue();
       _ota->CommandHandler((uint8_t*)data.c_str(), pCharacteristic->getValue().length());


### PR DESCRIPTION
The onWrite callbacks in `NimBLEOTA.cpp` use the `NimBLEConnInfo&` parameter signature introduced in NimBLE-Arduino 2.x, but NimBLE-Arduino 1.4.x (the most widely used version with ESP32-Arduino) expects either:

```
void onWrite(NimBLECharacteristic* pCharacteristic);
void onWrite(NimBLECharacteristic* pCharacteristic, ble_gap_conn_desc* desc);
```

Because the callback classes don't use the override keyword, the compiler silently accepts the mismatched signatures. The `onWrite(NimBLECharacteristic*, NimBLEConnInfo&)` methods are treated as new unrelated functions rather than overrides of the virtual base class methods. As a result, the NimBLE stack calls the default no-op onWrite implementation, and no write from a BLE client ever reaches the BLEOTA command or firmware handlers.

The OTA service appears to work, clients can connect, discover services, negotiate MTU, and even write to characteristics (the ATT layer accepts the write and returns success) but the application-level CommandHandler and FWHandler are never invoked, so the device never sends the start ACK and the OTA upload times out.

Fix:
Add additional NimBLE-Arduino 1.4x compatible signatures in `NimBLErecvFWCallback` and `NimBLEcommandCallback`.
